### PR TITLE
LAPS-202: Add link to Defra account management page

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -265,6 +265,12 @@ export const config = convict({
       format: String,
       default: 'http://localhost:3000',
       env: 'APP_BASE_URL'
+    },
+    manageAccountUrl: {
+      doc: 'The Defra account management URL.',
+      format: String,
+      default: 'https://your-account.cpdev.cui.defra.gov.uk/management',
+      env: 'DEFRA_ACCOUNT_MANAGEMENT_URL'
     }
   },
   showBetaBanner: {

--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,10 +1,14 @@
+import { config } from '../../config.js'
+
 export function buildNavigation(request) {
   const translations = request?.app?.translations || {}
+  const defraAccountUrl = config.get('defraId.manageAccountUrl')
+
   return [
     {
       text: translations['your-defra-acco'],
-      href: '/defra-account',
-      current: request?.path === '/defra-account'
+      href: defraAccountUrl,
+      current: false
     },
     {
       text: translations['sign-out'],

--- a/src/config/nunjucks/context/build-navigation.test.js
+++ b/src/config/nunjucks/context/build-navigation.test.js
@@ -1,4 +1,8 @@
 import { buildNavigation } from './build-navigation.js'
+import { config } from '../../config.js'
+
+const manageDefraAccountUrl =
+  'https://your-account.cpdev.cui.defra.gov.uk/management'
 
 function mockRequest(options) {
   return {
@@ -12,6 +16,17 @@ function mockRequest(options) {
   }
 }
 
+config.get = vi.fn().mockImplementation((key) => {
+  const configValues = {
+    root: '/',
+    assetPath: '/public',
+    serviceName: 'EPR-LAPs',
+    showBetaBanner: true,
+    'defraId.manageAccountUrl': manageDefraAccountUrl
+  }
+  return configValues[key]
+})
+
 describe('#buildNavigation', () => {
   test('Should provide expected navigation details', () => {
     expect(
@@ -20,7 +35,7 @@ describe('#buildNavigation', () => {
       {
         current: false,
         text: 'Your Defra account',
-        href: '/defra-account'
+        href: manageDefraAccountUrl
       },
       {
         current: false,
@@ -35,7 +50,7 @@ describe('#buildNavigation', () => {
       {
         current: false,
         text: 'Your Defra account',
-        href: '/defra-account'
+        href: manageDefraAccountUrl
       },
       {
         current: false,

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -1,8 +1,12 @@
 import { vi } from 'vitest'
+import { config } from '../../config.js'
 
 const mockReadFileSync = vi.fn()
 const mockLoggerError = vi.fn()
 const mockgetUserSession = vi.fn()
+
+const manageDefraAccountUrl =
+  'https://your-account.cpdev.cui.defra.gov.uk/management'
 
 vi.mock('node:fs', async () => {
   const nodeFs = await import('node:fs')
@@ -22,6 +26,17 @@ describe('context and cache', () => {
     mockLoggerError.mockReset()
     mockgetUserSession.mockReset()
     vi.resetModules()
+
+    config.get = vi.fn().mockImplementation((key) => {
+      const configValues = {
+        root: '/',
+        assetPath: '/public',
+        serviceName: 'EPR-LAPs',
+        showBetaBanner: true,
+        'defraId.manageAccountUrl': manageDefraAccountUrl
+      }
+      return configValues[key]
+    })
   })
 
   describe('#context', () => {
@@ -67,7 +82,7 @@ describe('context and cache', () => {
             {
               current: false,
               text: 'Your Defra account',
-              href: '/defra-account'
+              href: manageDefraAccountUrl
             },
             {
               current: false,
@@ -174,7 +189,7 @@ describe('context and cache', () => {
             {
               current: false,
               text: 'Your Defra account',
-              href: '/defra-account'
+              href: manageDefraAccountUrl
             },
             {
               current: false,


### PR DESCRIPTION
Add navigation when user selects 'Your Defra account', they will be directed to the Defra account management page.
Also requires config changes in cdp-app-config (https://github.com/DEFRA/cdp-app-config/pull/1725).
Unit tests added and passing.