### PR TITLE
LAPS-353: fetches authorization config from backend

### DIFF
--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -126,7 +126,8 @@ describe('context and cache', () => {
             laNames: { [EN_NAME]: CY_NAME },
             'sign-out': 'Sign out',
             'your-defra-acco': 'Your Defra account'
-          }
+          },
+          userPermissions: {}
         })
       })
 

--- a/src/server/bank-details/index.njk
+++ b/src/server/bank-details/index.njk
@@ -17,7 +17,7 @@
     }) }}
   {% endif %}
 
-{% if authedUser.currentRole == 'Head of Finance' and bankApiData.confirmed === false %}
+{% if userPermissions.confirmBankDetails and bankApiData.confirmed === false %}
   {% set htmlHof %}
     <p class="govuk-notification-banner__heading">
       {{ translations['please-confirm-'] }}<br>

--- a/src/server/home/index.njk
+++ b/src/server/home/index.njk
@@ -3,7 +3,7 @@
 {% set language = currentLang %}
 {% block content %}
   {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-   {% if authedUser.currentRole === 'Head of Finance' and bankApiData.confirmed === false %}
+   {% if userPermissions.confirmBankDetails and bankApiData.confirmed === false %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
- Fetches authorization config from backend and uses it on the frontend.
- Replaces hardcoded confirm bank detail roles for HOF.

Fetched data is of the form
```json
{
    "viewFullBankDetails": [
        "CEO"
    ],
    "confirmBankDetails": [
        "CEO",
        "WO"
    ],
    "listFinanceDocuments": [
        "CEO"
    ],
    "accessFinanceDocument": [
        "CEO"
    ]
}
 ```