### PR TITLE
Revert "added a 'recently added' tag for recent documents instead of displaying in bold"

### DIFF
--- a/src/client/common/locales/cy.json
+++ b/src/client/common/locales/cy.json
@@ -12,7 +12,6 @@
   "payment-documen": "Dogfennau talu",
   "you-can-view-an": "Gallwch chi weld a lawrlwytho:",
   "documents-relating": "amcangyfrif o symiau eich taliadau grant am Gyfrifoldeb Estynedig Cynhyrchwyr ar gyfer pecynwaith",
-  "recently-added": "Recently added",
   "remittance-advice": "eich hysbysiadau talu gyda manylion y taliadau",
   "bank-details": "Manylion banc",
   "you-can:": "Gallwch chi wneud y canlynol:",

--- a/src/client/common/locales/en.json
+++ b/src/client/common/locales/en.json
@@ -12,7 +12,6 @@
   "payment-documen": "Payment documents",
   "you-can-view-an": "You can view and download your:",
   "documents-relating": "estimated grant payment amounts for Extended Producer Responsibility (EPR) for packaging",
-  "recently-added": "Recently added",
   "remittance-advice": "remittance advice with payment details",
   "bank-details": "Bank details",
   "you-can:": "You can:",

--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -122,24 +122,16 @@ function buildTableRows(docsToShow, translations) {
     // Parse date in "DD Mon YYYY" format
     const [day, month, year] = doc.creationDate.split(' ')
 
-    const documentStatus = doc.isLatest
-      ? `<strong class='govuk-tag'>${translations['recently-added']}</strong>`
-      : ''
+    const boldClass = doc.isLatest ? 'bold-row' : ''
+
     const translationKey = getTranslationKey(doc.documentName)
     const docNameTranslated = translations[translationKey] || doc.documentName
     const monthTranslated = translations[month] || month
     const formattedDateTranslated = `${day} ${monthTranslated} ${year}`
 
     return [
-      {
-        text: formattedDateTranslated
-      },
-      {
-        text: docNameTranslated
-      },
-      {
-        html: documentStatus
-      },
+      { text: formattedDateTranslated, classes: boldClass },
+      { text: docNameTranslated, classes: boldClass },
       {
         html: `<a href='${downloadLink}' download class='govuk-link'>
                 ${translations.download}

--- a/src/server/payment-documents/controller.test.js
+++ b/src/server/payment-documents/controller.test.js
@@ -162,15 +162,17 @@ describe('paymentDocumentsController', () => {
     expect(Object.keys(metadata)).toEqual(['1', '2'])
   })
 
-  it('applies govuk-tag class only to documents within the last 30 days', async () => {
+  it('applies bold-row class only to documents within the last 30 days', async () => {
     request.yar.flash.mockReturnValue([])
     await paymentDocumentsController.handler(request, h)
 
     const viewArg = h.view.mock.calls[0][1]
     const [recentRow1, recentRow2] = viewArg.rows
 
-    expect(recentRow1[2].html).toContain('govuk-tag')
-    expect(recentRow2[2].html).toContain('govuk-tag')
+    expect(recentRow1[0].classes).toContain('bold-row')
+    expect(recentRow1[1].classes).toContain('bold-row')
+    expect(recentRow2[0].classes).toContain('bold-row')
+    expect(recentRow2[1].classes).toContain('bold-row')
   })
 
   it('handles missing docs for year/lang gracefully', async () => {
@@ -262,8 +264,8 @@ describe('paymentDocumentsController', () => {
         await paymentDocumentsController.handler(updatedRequest, h)
 
         const viewArg = h.view.mock.calls[0][1]
-        const doc1Html = viewArg.rows[0][3].html
-        const doc2Html = viewArg.rows[1][3].html
+        const doc1Html = viewArg.rows[0][2].html
+        const doc2Html = viewArg.rows[1][2].html
 
         expect(doc1Html).toContain(expectedFile1Name)
         expect(doc2Html).toContain(expectedFile2Name)
@@ -307,8 +309,8 @@ describe('paymentDocumentsController', () => {
       await paymentDocumentsController.handler(updatedRequest, h)
 
       const viewArg = h.view.mock.calls[0][1]
-      const doc1Html = viewArg.rows[0][3].html
-      const doc2Html = viewArg.rows[1][3].html
+      const doc1Html = viewArg.rows[0][2].html
+      const doc2Html = viewArg.rows[1][2].html
 
       expect(doc1Html).toContain('doc1_en.pdf')
       expect(doc2Html).toContain('doc2_en.pdf')

--- a/src/server/payment-documents/index.njk
+++ b/src/server/payment-documents/index.njk
@@ -52,9 +52,6 @@
       text: translations['document-name']
     },
     {
-      html: "<span class='govuk-visually-hidden'>Document status</span>"
-    },
-    {
       html: "<span class='govuk-visually-hidden'>Download document</span>"
     },
     {


### PR DESCRIPTION
Reverts DEFRA/epr-laps-frontend#301

This is because of issues with the tags not displaying correctly on mobile devices