### PR TITLE
LAPS-1514, LAPS-1509: Use latestFY to show the default year in fy dropdown

### DIFF
--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -104,7 +104,10 @@ export function buildFinancialYearOptions(
     return []
   }
 
-  const entries = Object.entries(documentApiData).slice(0, -1)
+  const entries = Object.entries(documentApiData).filter(
+    ([key]) => key !== 'currentFiscalYear' && key !== 'latestFinancialYear'
+  )
+
   return entries.map(([financialYear, _docs]) => ({
     value: financialYear,
     text: financialYear.replace(/\bto\b/, translations['to'] || 'to'),
@@ -157,7 +160,7 @@ export function findSelectedOption(isPost, request, documentApiData) {
   if (messages.length > 0 && !isPost) {
     return messages[0]
   }
-  return isPost ? request.payload.sort : documentApiData.currentFiscalYear
+  return isPost ? request.payload.sort : documentApiData.latestFinancialYear
 }
 
 /**

--- a/src/server/payment-documents/controller.test.js
+++ b/src/server/payment-documents/controller.test.js
@@ -476,7 +476,8 @@ describe('findSelectedOption', () => {
 
   it('should return flash value when not post and flash exists', () => {
     const result = findSelectedOption(false, request, {
-      currentFiscalYear: '2023 to 2024'
+      currentFiscalYear: '2023 to 2024',
+      latestFinancialYear: '2024 to 2025'
     })
     expect(result).toBe('2022 to 2023')
   })
@@ -491,8 +492,9 @@ describe('findSelectedOption', () => {
   it('should return current fiscal year when not post and no flash', () => {
     request.yar.flash.mockReturnValueOnce([])
     const result = findSelectedOption(false, request, {
-      currentFiscalYear: '2023 to 2024'
+      currentFiscalYear: '2023 to 2024',
+      latestFinancialYear: '2024 to 2025'
     })
-    expect(result).toBe('2023 to 2024')
+    expect(result).toBe('2024 to 2025')
   })
 })


### PR DESCRIPTION
**Root Cause of https://eaflood.atlassian.net/browse/LAPS-1514: Document drop down not defaulting to latest FY by default:**

- The document dropdown defaulted to the configured currentFiscalYear rather than the financial year of the most recently available document.
- As a result, when newer documents existed in a later financial year, the latest financial year was not automatically selected on page load.

**Fix (Also covers : https://eaflood.atlassian.net/browse/LAPS-1509: Reorder Payment Documents by Latest Created Date)**

- Documents are sorted by creationDate in descending order so the most recently uploaded documents are processed first.
- A new latestFinancialYear value is derived from the latest available document.
- currentFiscalYear is retained for the financial year warning message.
- The dropdown default selection now uses latestFinancialYear instead of currentFiscalYear.
- Updated the financial year dropdown logic to exclude metadata properties (currentFiscalYear and latestFinancialYear) from the selectable options.