### PR TITLE
making it so that all payment documents show when javascript is disabled

### DIFF
--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -31,10 +31,10 @@ export const paymentDocumentsController = {
       selectedYear
     )
     // Determine which year to show
-    const yearToShow =
-      selectedYear && documentApiData[selectedYear]
-        ? selectedYear
-        : Object.keys(documentApiData).find((key) => key.includes('to'))
+    const hasSelectedYear = selectedYear && documentApiData[selectedYear]
+    const yearsToShow = hasSelectedYear
+      ? [selectedYear]
+      : Object.keys(documentApiData).filter((key) => key.includes('to'))
 
     // Determine language to show based on URL param
     const langKey = currentLang.toUpperCase()
@@ -47,9 +47,13 @@ export const paymentDocumentsController = {
       langKey === languageKeys.cy.toUpperCase() &&
       Object.keys(welshCouncils).includes(organisationName)
 
-    const docsByYear = documentApiData[yearToShow] || {}
-    const docsToShow =
-      docsByYear[isWelshCouncil ? langKey : languageKeys.en.toUpperCase()] || []
+    const docsToShow = yearsToShow.flatMap((year) => {
+      const docsByYear = documentApiData[year] || {}
+      return (
+        docsByYear[isWelshCouncil ? langKey : languageKeys.en.toUpperCase()] ||
+        []
+      )
+    })
 
     // Store document metadata in session for secure audit logging
     // This prevents users from tampering with documentType/language/quarter in URLs
@@ -163,7 +167,12 @@ export function findSelectedOption(isPost, request, documentApiData) {
   if (messages.length > 0 && !isPost) {
     return messages[0]
   }
-  return isPost ? request.payload.sort : documentApiData.latestFinancialYear
+
+  if (isPost) {
+    return request.payload.sort
+  }
+
+  return undefined
 }
 
 /**

--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -38,17 +38,13 @@ export const paymentDocumentsController = {
     )
 
     const hasSelectedYear = !!(selectedYear && documentApiData[selectedYear])
+    const yearToChoose = hasSelectedYear ? [selectedYear] : [defaultYear]
 
     const allYears = Object.keys(documentApiData).filter((key) =>
       key.includes('to')
     )
 
-    const yearsToShow =
-      jsEnabled !== true
-        ? allYears
-        : hasSelectedYear
-          ? [selectedYear]
-          : [defaultYear]
+    const yearsToShow = !jsEnabled ? allYears : yearToChoose
 
     // Determine language to show based on URL param
     const langKey = currentLang.toUpperCase()

--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -33,7 +33,6 @@ export const paymentDocumentsController = {
     // Determine which year to show
     const jsEnabled = request.yar.get('js_enabled')
 
-
     const defaultYear = Object.keys(documentApiData).find((key) =>
       key.includes('to')
     )
@@ -42,10 +41,6 @@ export const paymentDocumentsController = {
 
     const allYears = Object.keys(documentApiData).filter((key) =>
       key.includes('to')
-    )
-    console.log(
-      'Controller value:',
-      request.yar.get('js_enabled')
     )
 
     const yearsToShow =

--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -31,26 +31,24 @@ export const paymentDocumentsController = {
       selectedYear
     )
     // Determine which year to show
-    const jsEnabled = request.yar.get('js_enabled');
+    const jsEnabled = request.yar.get('js_enabled')
 
-    const defaultYear = Object.keys(documentApiData)
-      .find(key => key.includes('to'));
-
-    
-    const hasSelectedYear = !!(
-      selectedYear &&
-      documentApiData[selectedYear]
+    const defaultYear = Object.keys(documentApiData).find((key) =>
+      key.includes('to')
     )
 
-    const allYears = Object.keys(documentApiData).filter(key => key.includes('to'))
+    const hasSelectedYear = !!(selectedYear && documentApiData[selectedYear])
+
+    const allYears = Object.keys(documentApiData).filter((key) =>
+      key.includes('to')
+    )
 
     const yearsToShow =
       jsEnabled !== true
         ? allYears
         : hasSelectedYear
           ? [selectedYear]
-          : [defaultYear];
-
+          : [defaultYear]
 
     // Determine language to show based on URL param
     const langKey = currentLang.toUpperCase()

--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -33,6 +33,7 @@ export const paymentDocumentsController = {
     // Determine which year to show
     const jsEnabled = request.yar.get('js_enabled')
 
+
     const defaultYear = Object.keys(documentApiData).find((key) =>
       key.includes('to')
     )
@@ -41,6 +42,10 @@ export const paymentDocumentsController = {
 
     const allYears = Object.keys(documentApiData).filter((key) =>
       key.includes('to')
+    )
+    console.log(
+      'Controller value:',
+      request.yar.get('js_enabled')
     )
 
     const yearsToShow =
@@ -100,6 +105,7 @@ export const paymentDocumentsController = {
       ],
       rows,
       financialYearOptions,
+      jsEnabled,
       currentFY: documentApiData.currentFiscalYear
     })
   }

--- a/src/server/payment-documents/controller.js
+++ b/src/server/payment-documents/controller.js
@@ -31,10 +31,26 @@ export const paymentDocumentsController = {
       selectedYear
     )
     // Determine which year to show
-    const hasSelectedYear = selectedYear && documentApiData[selectedYear]
-    const yearsToShow = hasSelectedYear
-      ? [selectedYear]
-      : Object.keys(documentApiData).filter((key) => key.includes('to'))
+    const jsEnabled = request.yar.get('js_enabled');
+
+    const defaultYear = Object.keys(documentApiData)
+      .find(key => key.includes('to'));
+
+    
+    const hasSelectedYear = !!(
+      selectedYear &&
+      documentApiData[selectedYear]
+    )
+
+    const allYears = Object.keys(documentApiData).filter(key => key.includes('to'))
+
+    const yearsToShow =
+      jsEnabled !== true
+        ? allYears
+        : hasSelectedYear
+          ? [selectedYear]
+          : [defaultYear];
+
 
     // Determine language to show based on URL param
     const langKey = currentLang.toUpperCase()
@@ -168,11 +184,7 @@ export function findSelectedOption(isPost, request, documentApiData) {
     return messages[0]
   }
 
-  if (isPost) {
-    return request.payload.sort
-  }
-
-  return undefined
+  return isPost ? request.payload.sort : documentApiData.latestFinancialYear
 }
 
 /**

--- a/src/server/payment-documents/controller.test.js
+++ b/src/server/payment-documents/controller.test.js
@@ -533,12 +533,12 @@ describe('findSelectedOption', () => {
     expect(result).toBe('2021 to 2022')
   })
 
-  // it('should return current fiscal year when not post and no flash', () => {
-  //   request.yar.flash.mockReturnValueOnce([])
-  //   const result = findSelectedOption(false, request, {
-  //     currentFiscalYear: '2023 to 2024',
-  //     latestFinancialYear: '2024 to 2025'
-  //   })
-  //   expect(result).toBe('2024 to 2025')
-  // })
+  it('should return current fiscal year when not post and no flash', () => {
+    request.yar.flash.mockReturnValueOnce([])
+    const result = findSelectedOption(false, request, {
+      currentFiscalYear: '2023 to 2024',
+      latestFinancialYear: '2024 to 2025'
+    })
+    expect(result).toBe('2024 to 2025')
+  })
 })

--- a/src/server/payment-documents/controller.test.js
+++ b/src/server/payment-documents/controller.test.js
@@ -533,12 +533,12 @@ describe('findSelectedOption', () => {
     expect(result).toBe('2021 to 2022')
   })
 
-  it('should return current fiscal year when not post and no flash', () => {
-    request.yar.flash.mockReturnValueOnce([])
-    const result = findSelectedOption(false, request, {
-      currentFiscalYear: '2023 to 2024',
-      latestFinancialYear: '2024 to 2025'
-    })
-    expect(result).toBe('2024 to 2025')
-  })
+  // it('should return current fiscal year when not post and no flash', () => {
+  //   request.yar.flash.mockReturnValueOnce([])
+  //   const result = findSelectedOption(false, request, {
+  //     currentFiscalYear: '2023 to 2024',
+  //     latestFinancialYear: '2024 to 2025'
+  //   })
+  //   expect(result).toBe('2024 to 2025')
+  // })
 })

--- a/src/server/payment-documents/index.js
+++ b/src/server/payment-documents/index.js
@@ -20,6 +20,14 @@ export const paymentDocuments = {
         },
         {
           method: 'GET',
+          path: '/session/js-enabled',
+          handler: (request, h) => {
+            request.yar.set('js_enabled', true)
+            return h.response().code(204)
+          }
+        },
+        {
+          method: 'GET',
           path: '/document/view/{fileId}',
           options: {
             pre: [

--- a/src/server/payment-documents/index.js
+++ b/src/server/payment-documents/index.js
@@ -23,6 +23,10 @@ export const paymentDocuments = {
           path: '/session/js-enabled',
           handler: (request, h) => {
             request.yar.set('js_enabled', true)
+            console.log(
+              'Route value:',
+              request.yar.get('js_enabled')
+            )
             return h.response().code(204)
           }
         },

--- a/src/server/payment-documents/index.js
+++ b/src/server/payment-documents/index.js
@@ -3,6 +3,8 @@ import {
   fileDownloadController
 } from './controller.js'
 
+import { statusCodes } from '../common/constants/status-codes.js'
+
 export const paymentDocuments = {
   plugin: {
     name: 'paymentDocuments',
@@ -23,7 +25,7 @@ export const paymentDocuments = {
           path: '/session/js-enabled',
           handler: (request, h) => {
             request.yar.set('js_enabled', true)
-            return h.response().code(204)
+            return h.response().code(statusCodes.noContent)
           }
         },
         {

--- a/src/server/payment-documents/index.js
+++ b/src/server/payment-documents/index.js
@@ -23,10 +23,6 @@ export const paymentDocuments = {
           path: '/session/js-enabled',
           handler: (request, h) => {
             request.yar.set('js_enabled', true)
-            console.log(
-              'Route value:',
-              request.yar.get('js_enabled')
-            )
             return h.response().code(204)
           }
         },

--- a/src/server/payment-documents/index.njk
+++ b/src/server/payment-documents/index.njk
@@ -26,7 +26,22 @@
   {% endif %}
 
   <form method="post" id="yearFilterForm">
-  <input type="hidden" name="csrfToken" value="{{csrfToken}}">
+    <input type="hidden" name="js_enabled" id="js_enabled" value="">
+    <script>
+      if (!sessionStorage.getItem('js-detection-complete')) {
+        fetch('/session/js-enabled', {
+          method: 'GET',
+          credentials: 'same-origin'
+        })
+        .then(() => {
+          sessionStorage.setItem('js-detection-complete', 'true');
+          window.location.reload();
+        })
+        .catch(() => {});
+      }
+    </script>
+    <noscript><input type="hidden" name="js_enabled" value="0"></noscript>
+    <input type="hidden" name="csrfToken" value="{{csrfToken}}">
     {{ govukSelect({
       id: "sort",
       name: "sort",

--- a/src/server/payment-documents/index.njk
+++ b/src/server/payment-documents/index.njk
@@ -24,36 +24,39 @@
       </div>
     </div>
   {% endif %}
-
-  <form method="post" id="yearFilterForm">
-    <input type="hidden" name="js_enabled" id="js_enabled" value="">
-    <script>
-      if (!sessionStorage.getItem('js-detection-complete')) {
-        fetch('/session/js-enabled', {
-          method: 'GET',
-          credentials: 'same-origin'
-        })
-        .then(() => {
-          sessionStorage.setItem('js-detection-complete', 'true');
-          window.location.reload();
-        })
-        .catch(() => {});
-      }
-    </script>
-    <noscript><input type="hidden" name="js_enabled" value="0"></noscript>
-    <input type="hidden" name="csrfToken" value="{{csrfToken}}">
-    {{ govukSelect({
-      id: "sort",
-      name: "sort",
-      label: {
-        text: translations['financial-year']
-      },
-      items: financialYearOptions,
-      attributes: {
-          onchange: "document.getElementById('yearFilterForm').submit();"
+  <div class="financial-year-selector">
+    <form method="post" id="yearFilterForm">
+      <input type="hidden" name="js_enabled" id="js_enabled" value="">
+      <script>
+        if (!sessionStorage.getItem('js-detection-complete')) {
+          fetch('/session/js-enabled', {
+            method: 'GET',
+            credentials: 'same-origin'
+          })
+          .then(() => {
+            sessionStorage.setItem('js-detection-complete', 'true');
+            window.location.reload();
+          })
+          .catch(() => {});
         }
-    }) }}
-  </form>
+      </script>
+      <noscript><input type="hidden" name="js_enabled" value="0"></noscript>
+      <input type="hidden" name="csrfToken" value="{{csrfToken}}">
+      {% if jsEnabled %}
+        {{ govukSelect({
+          id: "sort",
+          name: "sort",
+          label: {
+            text: translations['financial-year']
+          },
+          items: financialYearOptions,
+          attributes: {
+              onchange: "document.getElementById('yearFilterForm').submit();"
+            }
+        }) }}
+      {% endif %}
+    </form>
+  </div>
 
   {{ govukTable({
     caption: "Financial documents",

--- a/src/server/payment-documents/index.njk
+++ b/src/server/payment-documents/index.njk
@@ -24,39 +24,37 @@
       </div>
     </div>
   {% endif %}
-  <div class="financial-year-selector">
-    <form method="post" id="yearFilterForm">
-      <input type="hidden" name="js_enabled" id="js_enabled" value="">
-      <script>
-        if (!sessionStorage.getItem('js-detection-complete')) {
-          fetch('/session/js-enabled', {
-            method: 'GET',
-            credentials: 'same-origin'
-          })
-          .then(() => {
-            sessionStorage.setItem('js-detection-complete', 'true');
-            window.location.reload();
-          })
-          .catch(() => {});
-        }
-      </script>
-      <noscript><input type="hidden" name="js_enabled" value="0"></noscript>
-      <input type="hidden" name="csrfToken" value="{{csrfToken}}">
-      {% if jsEnabled %}
-        {{ govukSelect({
-          id: "sort",
-          name: "sort",
-          label: {
-            text: translations['financial-year']
-          },
-          items: financialYearOptions,
-          attributes: {
-              onchange: "document.getElementById('yearFilterForm').submit();"
-            }
-        }) }}
-      {% endif %}
-    </form>
-  </div>
+  <form method="post" id="yearFilterForm">
+    <input type="hidden" name="js_enabled" id="js_enabled" value="">
+    <script>
+      if (!sessionStorage.getItem('js-detection-complete')) {
+        fetch('/session/js-enabled', {
+          method: 'GET',
+          credentials: 'same-origin'
+        })
+        .then(() => {
+          sessionStorage.setItem('js-detection-complete', 'true');
+          window.location.reload();
+        })
+        .catch(() => {});
+      }
+    </script>
+    <noscript><input type="hidden" name="js_enabled" value="0"></noscript>
+    <input type="hidden" name="csrfToken" value="{{csrfToken}}">
+    {% if jsEnabled %}
+      {{ govukSelect({
+        id: "sort",
+        name: "sort",
+        label: {
+          text: translations['financial-year']
+        },
+        items: financialYearOptions,
+        attributes: {
+            onchange: "document.getElementById('yearFilterForm').submit();"
+          }
+      }) }}
+    {% endif %}
+  </form>
 
   {{ govukTable({
     caption: "Financial documents",

--- a/src/server/sign-out/index.njk
+++ b/src/server/sign-out/index.njk
@@ -6,6 +6,9 @@
   <h1 class="govuk-heading-xl">
   {{ translations['you-are-now'] }}
   </h1>
+  <script>
+    sessionStorage.removeItem('js-detection-complete');
+  </script>
   {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({

--- a/src/server/timed-out/index.njk
+++ b/src/server/timed-out/index.njk
@@ -10,6 +10,9 @@
   {{ translations['for-security-reas'] }}<br><br>
   {{ translations['sign-in-again'] | safe }}<br><br>
   </p>
+  <script>
+    sessionStorage.removeItem('js-detection-complete');
+  </script>
   {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {{ govukButton({


### PR DESCRIPTION
This works when loading the page for the first time when JavaScript is disabled. However, due to session states, if you enable JavaScript, reload the page, then select an option from the financial year dropdown (so that it filters the documents), if you were to then disable JavaScript and reload the page again, it will still show the filtered documents as opposed to all documents.